### PR TITLE
Update to support Credentials plugin select widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
-# Slack plugin for Jenkins - [![Build Status][jenkins-status]][jenkins-builds] [![Slack Signup][slack-badge]][slack-signup]
+Slack plugin for Jenkins  [![Build Status][jenkins-status]][jenkins-builds] [![Slack Signup][slack-badge]][slack-signup]
+----------------------------------------------------------------
 
-Started with a fork of the HipChat plugin:
+Provides Jenkins notification integration with Slack.
 
-https://github.com/jlewallen/jenkins-hipchat-plugin
+## Install Instructions
 
-Which was, in turn, a fork of the Campfire plugin.
+1. Get a Slack account: https://slack.com/
+2. Configure the Jenkins integration: https://my.slack.com/services/new/jenkins-ci
+3. Install this plugin on your Jenkins server
+4. Configure it in your Jenkins job (and optionally as global configuration) and **add it as a Post-build action**.
+
+#### Security
+
+Use Jenkins Credentials and a credential ID to configure the Slack integration token. It is a security risk to expose your integration token using the previous *Integration Token* setting.
+
+Create a new ***Secret text*** credential:
+![image](https://cloud.githubusercontent.com/assets/983526/17971588/6c26dfa0-6aa9-11e6-808c-3e139446e013.png)
+
+
+Select that credential as the value for the ***Integration Token Credential ID*** field:
+![image](https://cloud.githubusercontent.com/assets/983526/17971458/ec296bf6-6aa8-11e6-8d19-06d9f1c9d611.png)
+
+#### Jenkins Pipeline Support
 
 Includes [Jenkins Pipeline](https://github.com/jenkinsci/workflow-plugin) support as of version 2.0:
 
@@ -12,14 +29,7 @@ Includes [Jenkins Pipeline](https://github.com/jenkinsci/workflow-plugin) suppor
 slackSend color: 'good', message: 'Message from Jenkins Pipeline'
 ```
 
-# Jenkins Instructions
-
-1. Get a Slack account: https://slack.com/
-2. Configure the Jenkins integration: https://my.slack.com/services/new/jenkins-ci
-3. Install this plugin on your Jenkins server
-4. Configure it in your Jenkins job and **add it as a Post-build action**.
-
-# Developer instructions
+### Developer instructions
 
 Install Maven and JDK.  This was last build with Maven 3.2.5 and OpenJDK
 1.7.0\_75 on KUbuntu 14.04.

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -284,6 +284,12 @@ public class SlackNotifier extends Notifier {
                     );
         }
 
+        //WARN users that they should not use the plain/exposed token, but rather the token credential id
+        public FormValidation doCheckToken(@QueryParameter String value) {
+            //always show the warning - TODO investigate if there is a better way to handle this
+            return FormValidation.warning("Exposing your Integration Token is a security risk. Please use the Integration Token Credential ID");
+        }
+
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
             return true;
         }

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -66,6 +66,7 @@ public class StandardSlackService implements SlackService {
 
                 json.put("channel", roomId);
                 json.put("attachments", attachments);
+                json.put("link_names", "1");
 
                 post.addParameter("payload", json.toString());
                 post.getParams().setContentCharset("UTF-8");

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -8,6 +8,7 @@ import hudson.Util;
 import hudson.model.Project;
 import hudson.model.TaskListener;
 import hudson.security.ACL;
+import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import jenkins.plugins.slack.Messages;
@@ -22,6 +23,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -135,6 +137,12 @@ public class SlackSendStep extends AbstractStepImpl {
                             ACL.SYSTEM,
                             new HostnameRequirement("*.slack.com"))
                     );
+        }
+
+        //WARN users that they should not use the plain/exposed token, but rather the token credential id
+        public FormValidation doCheckToken(@QueryParameter String value) {
+            //always show the warning - TODO investigate if there is a better way to handle this
+            return FormValidation.warning("Exposing your Integration Token is a security risk. Please use the Integration Token Credential ID");
         }
     }
 

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -1,5 +1,5 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry title="Notify Build Start">
         <f:checkbox name="slackStartNotification" value="true" checked="${instance.getStartNotification()}"/>
     </f:entry>
@@ -38,7 +38,7 @@
         </f:entry>
 
         <f:optionalBlock name="includeCustomMessage" title="Include Custom Message" checked="${instance.includeCustomMessage()}">
-            <f:entry title="Custom Message" help="${rootURL}/plugin/slack/help-projectConfig-slackCustomMessage.html">
+            <f:entry title="Custom Message" help="/plugin/slack/help-projectConfig-slackCustomMessage.html">
                 <f:textarea name="customMessage" value="${instance.getCustomMessage()}"/>
             </f:entry>
         </f:optionalBlock>
@@ -51,23 +51,23 @@
             </select>
         </f:entry>
 
-        <f:entry title="Team Subdomain" help="${rootURL}/plugin/slack/help-projectConfig-slackTeamDomain.html">
+        <f:entry title="Team Subdomain" help="/plugin/slack/help-projectConfig-slackTeamDomain.html">
             <f:textbox name="slackTeamDomain" value="${instance.getTeamDomain()}"/>
         </f:entry>
 
-        <f:entry title="Integration Token" help="${rootURL}/plugin/slack/help-projectConfig-slackToken.html">
+        <f:entry title="Integration Token" help="/plugin/slack/help-projectConfig-slackToken.html">
             <f:textbox name="slackToken" value="${instance.getAuthToken()}"/>
         </f:entry>
 
-        <f:entry title="Integration Token Credential ID" help="${rootURL}/plugin/slack/help-projectConfig-slackTokenCredentialId.html">
-            <f:textbox name="slackTokenCredentialId" value="${instance.getAuthTokenCredentialId()}"/>
+        <f:entry title="Integration Token Credential ID" help="/plugin/slack/help-projectConfig-slackTokenCredentialId.html" field="tokenCredentialId" name="tokenCredentialId" >
+            <c:select value="${instance.getAuthTokenCredentialId()}"/>
         </f:entry>
 
-        <f:entry title="Project Channel" help="${rootURL}/plugin/slack/help-projectConfig-slackRoom.html">
+        <f:entry title="Project Channel" help="/plugin/slack/help-projectConfig-slackRoom.html">
             <f:textbox name="slackRoom" value="${instance.getRoom()}"/>
         </f:entry>
         <f:validateButton
                 title="${%Test Connection}" progress="${%Testing...}"
-                method="testConnection" with="slackTeamDomain,slackToken,slackTokenCredentialId,slackRoom"/>
+                method="testConnection" with="slackTeamDomain,slackToken,tokenCredentialId,slackRoom"/>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -56,7 +56,7 @@
         </f:entry>
 
         <f:entry title="Integration Token" help="/plugin/slack/help-projectConfig-slackToken.html">
-            <f:textbox name="slackToken" value="${instance.getAuthToken()}"/>
+            <f:textbox field="token" name="slackToken" value="${instance.getAuthToken()}"/>
         </f:entry>
 
         <f:entry title="Integration Token Credential ID" help="/plugin/slack/help-projectConfig-slackTokenCredentialId.html" field="tokenCredentialId" name="tokenCredentialId" >

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -1,4 +1,4 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <!--
     This Jelly script is used to produce the global configuration option.
 
@@ -12,20 +12,23 @@
     so it should be straightforward to find them.
   -->
 <f:section title="Global Slack Notifier Settings" name="slack">
-    <f:entry title="Team Subdomain" help="${rootURL}/plugin/slack/help-globalConfig-slackTeamDomain.html">
+    <f:entry title="Team Subdomain" help="/plugin/slack/help-globalConfig-slackTeamDomain.html">
         <f:textbox field="teamDomain" name="slackTeamDomain" value="${descriptor.getTeamDomain()}" />
     </f:entry>
-    <f:entry title="Integration Token" help="${rootURL}/plugin/slack/help-globalConfig-slackToken.html">
+    <f:entry title="Integration Token" help="/plugin/slack/help-globalConfig-slackToken.html">
         <f:textbox field="token" name="slackToken" value="${descriptor.getToken()}" />
     </f:entry>
-    <f:entry title="Channel" help="${rootURL}/plugin/slack/help-globalConfig-slackRoom.html">
+    <f:entry title="Integration Token Credential ID" field="tokenCredentialId" name="tokenCredentialId" help="/plugin/slack/help-globalConfig-tokenCredentialId.html">
+        <c:select/>
+    </f:entry>
+    <f:entry title="Channel" help="/plugin/slack/help-globalConfig-slackRoom.html">
         <f:textbox field="room" name="slackRoom" value="${descriptor.getRoom()}" />
     </f:entry>
-    <f:entry title="Build Server URL" help="${rootURL}/plugin/slack/help-globalConfig-slackBuildServerUrl.html">
+    <f:entry title="Build Server URL" help="/plugin/slack/help-globalConfig-slackBuildServerUrl.html">
         <f:textbox field="buildServerUrl" name="slackBuildServerUrl" value="${descriptor.getBuildServerUrl()}" />
     </f:entry>
     <f:validateButton
         title="${%Test Connection}" progress="${%Testing...}"
-        method="testConnection" with="slackTeamDomain,slackToken,slackRoom,slackBuildServerUrl" />
+        method="testConnection" with="slackTeamDomain,slackToken,tokenCredentialId,slackRoom,slackBuildServerUrl" />
   </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
@@ -11,7 +11,7 @@
         <f:entry field="channel" title="Channel">
             <f:textbox />
         </f:entry>
-        <f:entry field="tokenCredentialId" title="Integration Token">
+        <f:entry field="tokenCredentialId" title="Integration Token Credential ID">
              <c:select/>
         </f:entry>
         <f:entry field="token" title="Integration Token">

--- a/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry field="message" title="Message">
         <f:textbox/>
     </f:entry>
@@ -10,6 +10,9 @@
     <f:advanced>
         <f:entry field="channel" title="Channel">
             <f:textbox />
+        </f:entry>
+        <f:entry field="tokenCredentialId" title="Integration Token">
+             <c:select/>
         </f:entry>
         <f:entry field="token" title="Integration Token">
             <f:textbox />

--- a/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/help-tokenCredentialId.html
+++ b/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/help-tokenCredentialId.html
@@ -1,0 +1,4 @@
+<div>
+    <p>The ID for the integration token from the Credentials plugin to be used to send notifications to Slack.  The "Kind" of the credential must be "Secret text."  If both "Integration Token" and "Integration Token Credential ID" are set, the "Integration Token Credential ID" will take precedence for security reasons.</p>
+    <p>This overrides the global setting.</p>
+</div>

--- a/src/main/webapp/help-globalConfig-tokenCredentialId.html
+++ b/src/main/webapp/help-globalConfig-tokenCredentialId.html
@@ -1,0 +1,3 @@
+<div>
+	<p>The ID for the integration token from the Credentials plugin to be used to send notifications to Slack.  The "Kind" of the credential must be "Secret text."  If both "Integration Token" and "Integration Token Credential ID" are set, the "Integration Token Credential ID" will take precedence for security reasons.</p>
+</div>


### PR DESCRIPTION
@fgs-dbudwin  Example of integrating with xmlns:c="/lib/credentials" c:select for selecting credentials. Feel free to merge or not.

Create credential set:
![image](https://cloud.githubusercontent.com/assets/983526/17971588/6c26dfa0-6aa9-11e6-808c-3e139446e013.png)

Apply to Slack configuration:
![image](https://cloud.githubusercontent.com/assets/983526/17971458/ec296bf6-6aa8-11e6-8d19-06d9f1c9d611.png)
